### PR TITLE
Reuse LogEventProperty per request to reduce allocation

### DIFF
--- a/src/Serilog.Enrichers.ClientInfo/Enrichers/ClientAgentEnricher.cs
+++ b/src/Serilog.Enrichers.ClientInfo/Enrichers/ClientAgentEnricher.cs
@@ -13,7 +13,9 @@ namespace Serilog.Enrichers
 {
     public class ClientAgentEnricher : ILogEventEnricher
     {
-        private const string IpAddressPropertyName = "ClientAgent";
+        private const string ClientAgentPropertyName = "ClientAgent";
+        private const string ClientAgentItemKey = "Serilog_ClientAgent";
+
         private readonly IHttpContextAccessor _contextAccessor;
 
         public ClientAgentEnricher() : this(new HttpContextAccessor())
@@ -27,17 +29,27 @@ namespace Serilog.Enrichers
 
         public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
         {
-            if (_contextAccessor.HttpContext == null)
+            var httpContext = _contextAccessor.HttpContext;
+            if (httpContext == null)
                 return;
+
+            if (httpContext.Items[ClientAgentItemKey] is LogEventProperty logEventProperty)
+            {
+                logEvent.AddPropertyIfAbsent(logEventProperty);
+                return;
+            }
+
 #if NETFULL
-            var agentName = _contextAccessor.HttpContext.Request.Headers["User-Agent"];
+            var agentName = httpContext.Request.Headers["User-Agent"];
 #else
-            var agentName = _contextAccessor.HttpContext.Request.Headers["User-Agent"];
+            var agentName = httpContext.Request.Headers["User-Agent"];
 #endif
 
-            var ipAddressProperty = new LogEventProperty(IpAddressPropertyName, new ScalarValue(agentName));
 
-            logEvent.AddPropertyIfAbsent(ipAddressProperty);
+            var clientAgentProperty = new LogEventProperty(ClientAgentPropertyName, new ScalarValue(agentName));
+            httpContext.Items.Add(ClientAgentItemKey, clientAgentProperty);
+
+            logEvent.AddPropertyIfAbsent(clientAgentProperty);
         }
     }
 }

--- a/src/Serilog.Enrichers.ClientInfo/Enrichers/ClientIpEnricher.cs
+++ b/src/Serilog.Enrichers.ClientInfo/Enrichers/ClientIpEnricher.cs
@@ -16,6 +16,8 @@ namespace Serilog.Enrichers
     public class ClientIpEnricher : ILogEventEnricher
     {
         private const string IpAddressPropertyName = "ClientIp";
+        private const string IpAddresstItemKey = "Serilog_ClientIp";
+
         private readonly IHttpContextAccessor _contextAccessor;
 
         public ClientIpEnricher()
@@ -30,8 +32,15 @@ namespace Serilog.Enrichers
 
         public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
         {
-            if (_contextAccessor.HttpContext == null)
+            var httpContext = _contextAccessor.HttpContext;
+            if (httpContext == null)
                 return;
+
+            if (httpContext.Items[IpAddresstItemKey] is LogEventProperty logEventProperty)
+            {
+                logEvent.AddPropertyIfAbsent(logEventProperty);
+                return;
+            }
 
             var ipAddress = GetIpAddress();
 
@@ -39,6 +48,7 @@ namespace Serilog.Enrichers
                 ipAddress = "unknown";
 
             var ipAddressProperty = new LogEventProperty(IpAddressPropertyName, new ScalarValue(ipAddress));
+            httpContext.Items.Add(IpAddresstItemKey, ipAddressProperty);
 
             logEvent.AddPropertyIfAbsent(ipAddressProperty);
         }


### PR DESCRIPTION
Hello! 
What do you think about storing and reusing the `LogEventProperty` per request in order to reduce the allocation?